### PR TITLE
AnyBus_v2: Fix for `TypeError: Cannot read properties of undefined (reading 'type')` after deleting nodes

### DIFF
--- a/web/assets/js/AnyBus_v2.js
+++ b/web/assets/js/AnyBus_v2.js
@@ -562,14 +562,14 @@ class MaraScottAnyBusNodeFlow {
 			window.marascott.AnyBus_v2.nodes[_node.id] = _node
 		}
 		for (let i in _bus_nodes) {
-			_bus_node_link = _bus_nodes[i].inputs[0].link
+			_bus_node_link = _bus_nodes[i].inputs[0]?.link
 			if (_bus_node_link == 'setNode') {
-				if (_bus_nodes[i].inputs[0].origin_id) _bus_nodes_connections[_bus_nodes[i].id] = _bus_nodes[i].inputs[0].origin_id
+				if (_bus_nodes[i].inputs[0]?.origin_id) _bus_nodes_connections[_bus_nodes[i].id] = _bus_nodes[i].inputs[0]?.origin_id
 			} else if (_bus_node_link != null) {
 				_bus_node_link = node.graph.links.find(
 					(otherLink) => otherLink?.id == _bus_node_link
 				)
-				if (_bus_node_link) _bus_nodes_connections[_bus_nodes[i].id] = _bus_node_link.origin_id
+				if (_bus_node_link) _bus_nodes_connections[_bus_nodes[i].id] = _bus_node_link?.origin_id
 			} else {
 				node_paths_start.push(_bus_nodes[i].id)
 			}
@@ -583,7 +583,7 @@ class MaraScottAnyBusNodeFlow {
 			while (_bus_nodes_connections[currentNode] !== undefined) {
 				currentNode = _bus_nodes_connections[currentNode]; // Move to the parent node
 				const _currentNode = node.graph.getNodeById(currentNode)
-				if (_currentNode.type == MaraScottAnyBus_v2.TYPE) {
+				if (_currentNode?.type == MaraScottAnyBus_v2.TYPE) {
 					node_paths[id].push(currentNode); // Add the parent node to the path
 				}
 			}


### PR DESCRIPTION
Hi MaraScott,

this addresses an issue I was sometimes having when deleting groups of nodes that were connected to AnyBus.

```
TypeError: Cannot read properties of undefined (reading 'type')
    at MaraScottAnyBusNodeFlow.setFlows (AnyBus_v2.js:586:22)
    at MaraScottAnyBusNodeFlow.syncProfile (AnyBus_v2.js:603:28)
```

When the above js error was thrown in the console log, I wasn't able any longer to delete nodes nor create new connections to AnyBus nodes in the workflow.

It pretty much broke the workflow because the js error was preventing connecting nodes to each other - I suppose because of invalid and no longer existing references. I was able to fix it sometimes by manually deleting nodes in a specific order by trial and error.

I don't know if this is the best solution or if I missed something. But I've been using the code change for a couple of days now and haven't experienced any other problems so far.

Thank you for developing AnyBus! For me it's one of the most essential helper tools to build component based ComfyUI workflows.